### PR TITLE
refactor(frontend): improve Sider collapse and PythonManagePage structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@eslint/js": "9",
     "@tauri-apps/cli": "^2",
     "@types/eslint": "^9.6.1",
-    "@types/eslint__js": "^9.14.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -1,5 +1,7 @@
 {
   "switch_theme": "Switch Theme",
+  "collapse": "Collapse",
+  "expand": "Expand",
   "nav": {
     "go": "Go",
     "java": "Java",
@@ -17,7 +19,8 @@
   },
   "lang": {
     "zh": "中文",
-    "en": "English"
+    "en": "English",
+    "switch": "Switch Language"
   },
   "error": {
     "title": "Something went wrong",

--- a/src/features/i18n/locales/zh.json
+++ b/src/features/i18n/locales/zh.json
@@ -1,5 +1,7 @@
 {
   "switch_theme": "切换主题",
+  "collapse": "折叠",
+  "expand": "展开",
   "nav": {
     "go": "Go",
     "java": "Java",
@@ -17,7 +19,8 @@
   },
   "lang": {
     "zh": "中文",
-    "en": "English"
+    "en": "English",
+    "switch": "切换语言"
   },
   "error": {
     "title": "出错了",

--- a/src/features/version-manager/pages/PythonManagePage/index.tsx
+++ b/src/features/version-manager/pages/PythonManagePage/index.tsx
@@ -26,15 +26,14 @@ export const PythonManagePage = () => {
     void getList();
   }, [getList]);
 
-  const handleSearch = async (keyWord: string) => {
+  const handleSearch = (keyWord: string) => {
     setSearchPayload(prevState => ({ ...prevState, keyWord: keyWord }));
   };
 
-  const handleInstallToggle = async (record: VersionItem) => {
-    const command = record.install_status
-      ? InstallStatusEnum.UNINSTALLED
-      : InstallStatusEnum.INSTALLED;
-
+  const handleVersionAction = async (
+    command: CommandEnum | InstallStatusEnum,
+    record: VersionItem,
+  ) => {
     await safeInvoke(command, {
       language: LanguageEnum.PYTHON,
       version: record.version,
@@ -43,21 +42,7 @@ export const PythonManagePage = () => {
     await getList();
   };
 
-  const handleUseToggle = async (record: VersionItem) => {
-    await safeInvoke(CommandEnum.USE_VERSION, {
-      language: LanguageEnum.PYTHON,
-      version: record.version,
-    });
-
-    await getList();
-  };
-
   return (
-    <VersionTable
-      data={data}
-      onInstallToggle={handleInstallToggle}
-      onSearch={handleSearch}
-      onUseToggle={handleUseToggle}
-    />
+    <VersionTable data={data} handleVersionAction={handleVersionAction} onSearch={handleSearch} />
   );
 };

--- a/src/layouts/BasicLayout/Sider.tsx
+++ b/src/layouts/BasicLayout/Sider.tsx
@@ -1,6 +1,6 @@
 // src/layouts/BasicLayout/Sider.tsx
-import { SettingTwoTone } from '@ant-design/icons';
-import { Menu, Button, Select, MenuProps } from 'antd';
+import { MenuFoldOutlined, MenuUnfoldOutlined, SettingOutlined } from '@ant-design/icons';
+import { Menu, Button, Select, MenuProps, Tooltip, Popover } from 'antd';
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -13,14 +13,20 @@ import { IconFont } from '@/shared/components/IconFont';
 import { saveTheme } from '@/shared/utils/tauriStore';
 import { type RootState } from '@/store';
 
-export const Sider: React.FC<{ collapsed: boolean; onCollapse: () => void }> = ({ collapsed }) => {
+interface ISiderProps {
+  collapsed: boolean;
+  onCollapse: (status: boolean) => void;
+}
+
+export const Sider: React.FC<ISiderProps> = ({ collapsed, onCollapse }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const dispatch = useDispatch();
+  const { t } = useTranslation();
+
   const [selectedKey, setSelectedKey] = useState<string>(location.pathname);
   const mode = useSelector((state: RootState) => state.theme.mode);
   const [language, setLanguage] = useState<string>('zh');
-  const { t } = useTranslation();
 
   useEffect(() => {
     setSelectedKey(location.pathname);
@@ -34,7 +40,7 @@ export const Sider: React.FC<{ collapsed: boolean; onCollapse: () => void }> = (
     { label: t('nav.rust'), key: '/rust', icon: <IconFont type="icon-rust" /> },
     { label: t('nav.v'), key: '/v', icon: <IconFont type="icon-vlang" /> },
     { label: t('nav.zig'), key: '/zig', icon: <IconFont type="icon-zig" /> },
-    { label: t('nav.settings'), key: '/settings', icon: <SettingTwoTone /> },
+    { label: t('nav.settings'), key: '/settings', icon: <SettingOutlined /> },
     { label: t('nav.downloader'), key: '/downloader', icon: <IconFont type="icon-downloader" /> },
   ];
 
@@ -44,7 +50,6 @@ export const Sider: React.FC<{ collapsed: boolean; onCollapse: () => void }> = (
 
   const toggleTheme = async () => {
     const newMode = mode === 'light' ? 'dark' : 'light';
-
     dispatch(setMode(newMode));
     await saveTheme(newMode);
   };
@@ -55,30 +60,107 @@ export const Sider: React.FC<{ collapsed: boolean; onCollapse: () => void }> = (
   };
 
   return (
-    <div style={{ width: collapsed ? 80 : 200, transition: 'width 0.3s' }}>
-      <Menu
-        mode="inline"
-        selectedKeys={[selectedKey]}
-        onClick={handleMenuClick}
-        items={items.map(item => ({
-          key: item.key,
-          icon: item.icon,
-          label: collapsed ? null : item.label,
-        }))}
-      />
-      <div style={{ padding: '16px', textAlign: 'center' }}>
-        <Button onClick={toggleTheme} block>
-          {mode === 'dark' ? t('theme.light') : t('theme.dark')}
-        </Button>
-        <Select
-          value={language}
-          onChange={handleLanguageChange}
-          style={{ width: '100%', marginTop: '16px' }}
-          options={[
-            { value: LangEnum.ZH, label: t('lang.zh') },
-            { value: LangEnum.EN, label: t('lang.en') },
-          ]}
-        />
+    <div
+      style={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {/* 菜单 */}
+      <Menu mode="inline" selectedKeys={[selectedKey]} onClick={handleMenuClick} items={items} />
+
+      <div style={{ flex: 1 }} />
+
+      {/* 底部操作区 */}
+      <div style={{ padding: 16 }}>
+        {collapsed ? (
+          /* 折叠状态：纵向 */
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 12,
+              alignItems: 'center',
+            }}
+          >
+            <Tooltip title={mode === 'dark' ? t('theme.light') : t('theme.dark')} placement="right">
+              <Button
+                type="text"
+                shape="circle"
+                style={{ width: 40, height: 40 }}
+                icon={mode === 'dark' ? '☀️' : '🌙'}
+                onClick={toggleTheme}
+              />
+            </Tooltip>
+
+            <Popover
+              content={
+                <Select
+                  value={language}
+                  onChange={handleLanguageChange}
+                  style={{ width: 120 }}
+                  options={[
+                    { value: LangEnum.ZH, label: t('lang.zh') },
+                    { value: LangEnum.EN, label: t('lang.en') },
+                  ]}
+                />
+              }
+              placement="right"
+            >
+              <Button
+                type="text"
+                shape="circle"
+                style={{ width: 40, height: 40 }}
+                icon={<span>{language === LangEnum.ZH ? '中' : 'EN'}</span>}
+              />
+            </Popover>
+
+            <Tooltip title={t('expand')} placement="right">
+              <Button
+                type="text"
+                shape="circle"
+                style={{ width: 40, height: 40 }}
+                icon={<MenuUnfoldOutlined />}
+                onClick={() => onCollapse(!collapsed)}
+              />
+            </Tooltip>
+          </div>
+        ) : (
+          /* 展开状态：横向 */
+          <div
+            style={{
+              display: 'flex',
+              gap: 12,
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Tooltip title={mode === 'dark' ? t('theme.light') : t('theme.dark')}>
+              <Button type="text" icon={mode === 'dark' ? '☀️' : '🌙'} onClick={toggleTheme} />
+            </Tooltip>
+
+            <Tooltip title={t('lang.switch')}>
+              <Select
+                value={language}
+                onChange={handleLanguageChange}
+                style={{ width: 100 }}
+                options={[
+                  { value: LangEnum.ZH, label: t('lang.zh') },
+                  { value: LangEnum.EN, label: t('lang.en') },
+                ]}
+              />
+            </Tooltip>
+
+            <Tooltip title={collapsed ? t('expand') : t('collapse')}>
+              <Button
+                type="text"
+                icon={<MenuFoldOutlined />}
+                onClick={() => onCollapse(!collapsed)}
+              />
+            </Tooltip>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/layouts/BasicLayout/index.tsx
+++ b/src/layouts/BasicLayout/index.tsx
@@ -12,13 +12,15 @@ export const BasicLayout: React.FC = () => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <AntdSider width={200} theme="light" collapsed={collapsed}>
-        <Sider collapsed={collapsed} onCollapse={() => setCollapsed} />
+      <AntdSider width={200} theme="light" collapsed={collapsed} collapsible trigger={null}>
+        <Sider collapsed={collapsed} onCollapse={setCollapsed} />
       </AntdSider>
 
-      <Content style={{ padding: '16px' }}>
-        <Outlet />
-      </Content>
+      <Layout>
+        <Content style={{ padding: 16 }}>
+          <Outlet />
+        </Content>
+      </Layout>
     </Layout>
   );
 };

--- a/src/shared/components/VersionTable.tsx
+++ b/src/shared/components/VersionTable.tsx
@@ -3,6 +3,8 @@ import { Table, Input, Button } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { CommandEnum, InstallStatusEnum } from '@/core/constants/enum';
+
 const { Search } = Input;
 
 export interface VersionItem {
@@ -20,18 +22,30 @@ interface VersionTableProps {
   loading?: boolean;
 
   onSearch?: (value: string) => void;
-  onInstallToggle?: (record: VersionItem) => void;
-  onUseToggle?: (record: VersionItem) => void;
+  handleVersionAction?: (
+    command: CommandEnum | InstallStatusEnum,
+    record: VersionItem,
+  ) => Promise<void>;
 }
 
 export const VersionTable: React.FC<VersionTableProps> = ({
   data,
   loading,
   onSearch,
-  onInstallToggle,
-  onUseToggle,
+  handleVersionAction,
 }) => {
   const { t } = useTranslation();
+
+  const onInstallToggle = async (record: VersionItem) => {
+    const command = record.install_status
+      ? InstallStatusEnum.UNINSTALLED
+      : InstallStatusEnum.INSTALLED;
+    await handleVersionAction?.(command, record);
+  };
+
+  const onUseToggle = async (record: VersionItem) => {
+    await handleVersionAction?.(CommandEnum.USE_VERSION, record);
+  };
 
   const columns: TableProps<VersionItem>['columns'] = [
     {


### PR DESCRIPTION
refactor(frontend): improve Sider collapse and PythonManagePage structure

## 📌 变更类型

- [ ] 🐞 Bug 修复
- [x] ✨ 新功能
- [x] ♻️ 重构
- [ ] 📚 文档更新
- [ ] 🎨 代码风格改进
- [ ]  ⚡ 性能优化
- [ ] 🛡️ 安全改进
- [ ] 🔧 构建/CI 相关
- [ ] 📦 依赖更新
- [ ] 🔧 其他

---

## 🧾 变更说明

请简要说明本次 PR 做了什么。

 - Refactor PythonManagePage to use unified handleVersionAction function
   - Add collapse/expand functionality to Sider component with proper UI states
   - Add i18n support for collapse and expand labels
   - Update VersionTable to handle version actions internally
   - Remove unused dependency (@types/eslint__js)

   Features:
   - Collapsed state shows circular buttons with tooltips
   - Language switcher uses Popover with hover trigger in collapsed state
   - Theme toggle and language switch work in both collapsed and expanded states
   - Improved component structure and code reusability

---

## 🔍 相关 Issue

Closes #

---

## 🧪 测试情况

- [x] 本地运行通过
- [ ] cargo check 通过
- [ ] cargo fmt 已执行
- [x] 前端 lint 通过

---

## 📷 截图（如有）

<img width="2878" height="1596" alt="image" src="https://github.com/user-attachments/assets/8d39a08c-4b20-414a-abec-a46f95f9481c" />
<img width="2880" height="1462" alt="image" src="https://github.com/user-attachments/assets/077d0e0f-a7b1-413c-b885-176d03bd5069" />


---

## ⚠️ 注意事项

是否有破坏性更改？
否