### PR TITLE
feat(frontend): improve API response handling and settings page

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,13 +1,13 @@
 {
-    "printWidth": 100,
-    "tabWidth": 2,
-    "useTabs": false,
-    "semi": true,
-    "singleQuote": true,
-    "jsxSingleQuote": false,
-    "trailingComma": "all",
-    "bracketSpacing": true,
-    "bracketSameLine": false,
-    "arrowParens": "avoid",
-    "endOfLine": "crlf"
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "jsxSingleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "avoid",
+  "endOfLine": "crlf"
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,23 +13,12 @@ export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    ignores: [
-      'node_modules/**',
-      'dist/**',
-      'build/**',
-      'target/**',
-      'src-tauri/target/**',
-    ],
+    ignores: ['node_modules/**', 'dist/**', 'build/**', 'target/**', 'src-tauri/target/**'],
   },
 
   {
     files: ['src/**/*.{ts,tsx}'],
-    ignores: [
-      '.editorconfig',
-      '.gitignore',
-      '.prettierrc.js',
-      'README.md',
-    ],
+    ignores: ['.editorconfig', '.gitignore', '.prettierrc.js', 'README.md'],
 
     languageOptions: {
       parser: tsParser,
@@ -95,7 +84,6 @@ export default [
 
       /* ---------------- React Hooks ---------------- */
       'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'warn',
 
       /* ---------------- TypeScript ---------------- */
       '@typescript-eslint/no-floating-promises': [

--- a/src-tauri/src/core/common/response.rs
+++ b/src-tauri/src/core/common/response.rs
@@ -10,7 +10,7 @@ pub struct ApiResponse<T> {
 impl<T> ApiResponse<T> {
     pub fn success_with_data(data: T) -> Self {
         Self {
-            code: 10000,
+            code: 200,
             msg: "success".into(),
             data: Some(data),
         }
@@ -18,7 +18,7 @@ impl<T> ApiResponse<T> {
 
     pub fn success_with_msg() -> Self {
         Self {
-            code: 10000,
+            code: 200,
             msg: "success".into(),
             data: None,
         }
@@ -28,7 +28,7 @@ impl<T> ApiResponse<T> {
 impl<T> ApiResponse<T> {
     pub fn error(msg: &str) -> Self {
         Self {
-            code: 10001,
+            code: 500,
             msg: msg.into(),
             data: None,
         }

--- a/src/api/tauri.ts
+++ b/src/api/tauri.ts
@@ -8,6 +8,18 @@ import { mockResponse } from '@/mock/util';
 
 const isTauri = navigator.userAgent.includes('lvm');
 
+interface IApiResponse<T> {
+  data: T;
+  msg: string;
+  code: number;
+}
+
+const defaultErrorResponse: IApiResponse<undefined> = {
+  code: 500,
+  msg: 'Internal Error',
+  data: undefined,
+};
+
 /**
  * 安全 invoke
  * 浏览器模式不会报错
@@ -16,13 +28,24 @@ export async function safeInvoke<T>(
   command: CommandEnum | InstallStatusEnum,
   args?: InvokeArgs,
 ): Promise<T> {
+  let res: IApiResponse<T>;
+
   if (isMock && command in mockHandlers) {
     const handler = mockHandlers[command as keyof typeof mockHandlers];
 
-    return handler ? (mockResponse(handler()) as Promise<T>) : (undefined as T);
+    res = handler
+      ? ((await mockResponse<T>(handler() as unknown as T)) as IApiResponse<T>)
+      : (defaultErrorResponse as IApiResponse<T>);
+  } else if (!isTauri) {
+    res = defaultErrorResponse as IApiResponse<T>;
+  } else {
+    res = await tauriCore.invoke<IApiResponse<T>>(command, args);
   }
 
-  return !isTauri ? Promise.resolve(undefined as T) : tauriCore.invoke<T>(command, args);
-}
+  if (res.code !== 200) {
+    throw new Error(res.msg);
+  }
 
+  return res.data;
+}
 export { isTauri };

--- a/src/core/constants/enum.ts
+++ b/src/core/constants/enum.ts
@@ -4,6 +4,7 @@ export enum LangEnum {
 }
 
 export enum CommandEnum {
+  UPDATE_CONFIG = 'update_configs',
   GET_CONFIG_VALUES = 'get_config_values',
   LIST_VERSIONS = 'list_versions',
   USE_VERSION = 'use_version',

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -47,7 +47,9 @@
     "success": "Configuration saved, it will take effect on next installation",
     "base_path": "Base Path",
     "download_path": "Download Path",
-    "versions_path": "Versions Path"
+    "versions_path": "Versions Path",
+    "auto_activate": "Auto Activate",
+    "error": "Error"
   },
   "downloader": {
     "title": "Download Manager",

--- a/src/features/i18n/locales/zh.json
+++ b/src/features/i18n/locales/zh.json
@@ -47,7 +47,9 @@
     "success": "配置已保存，下次安装将生效",
     "base_path": "基础路径",
     "download_path": "下载路径",
-    "versions_path": "版本路径"
+    "versions_path": "版本路径",
+    "auto_activate": "自动激活",
+    "error": "操作失败"
   },
   "downloader": {
     "title": "下载管理",

--- a/src/features/version-manager/pages/PythonManagePage/index.tsx
+++ b/src/features/version-manager/pages/PythonManagePage/index.tsx
@@ -1,3 +1,4 @@
+import { message } from 'antd';
 import { useCallback, useEffect, useState } from 'react';
 
 import { safeInvoke } from '@/api/tauri';
@@ -6,6 +7,7 @@ import { SearchPayload, VersionItem, VersionResult } from '@/core/types/common.t
 import { VersionTable } from '@/shared/components/VersionTable';
 
 export const PythonManagePage = () => {
+  const [loading, setLoading] = useState(false);
   const [searchPayload, setSearchPayload] = useState<SearchPayload>({
     language: LanguageEnum.PYTHON,
     page: 0,
@@ -18,13 +20,20 @@ export const PythonManagePage = () => {
   });
 
   const getList = useCallback(async () => {
-    const result = await safeInvoke<VersionResult>(CommandEnum.LIST_VERSIONS, searchPayload);
-    setData(result);
+    try {
+      setLoading(true);
+      const data = await safeInvoke<VersionResult>(CommandEnum.LIST_VERSIONS, searchPayload);
+      setData(data);
+    } catch (error) {
+      message.error((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
   }, [searchPayload]);
 
   useEffect(() => {
     void getList();
-  }, [getList]);
+  }, []);
 
   const handleSearch = (keyWord: string) => {
     setSearchPayload(prevState => ({ ...prevState, keyWord: keyWord }));
@@ -43,6 +52,11 @@ export const PythonManagePage = () => {
   };
 
   return (
-    <VersionTable data={data} handleVersionAction={handleVersionAction} onSearch={handleSearch} />
+    <VersionTable
+      loading={loading}
+      data={data}
+      handleVersionAction={handleVersionAction}
+      onSearch={handleSearch}
+    />
   );
 };

--- a/src/features/version-manager/pages/Settings/index.tsx
+++ b/src/features/version-manager/pages/Settings/index.tsx
@@ -1,5 +1,5 @@
-import { Button, Card, Form, Input, message } from 'antd';
-import { useEffect, useState } from 'react';
+import { Button, Card, Form, Input, message, Switch } from 'antd';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { safeInvoke } from '@/api/tauri.ts';
@@ -7,71 +7,64 @@ import { CommandEnum } from '@/core/constants/enum.ts';
 import { keysToCamel } from '@/shared/utils/common';
 
 export const Settings = () => {
-  const [basePath, setBasePath] = useState('');
-  const [downloadPath, setDownloadPath] = useState('');
-  const [versionsPath, setVersionsPath] = useState('');
   const { t } = useTranslation();
+
+  const [form] = Form.useForm();
 
   useEffect(() => {
     const init = async () => {
-      try {
-        const defaultPath = await safeInvoke<string>(CommandEnum.BASE_PATH);
-        const configData = await safeInvoke<Record<string, boolean | string>>(
-          CommandEnum.GET_CONFIG_VALUES,
-          {
-            keys: [CommandEnum.VERSIONS_PATH, CommandEnum.DOWNLOAD_PATH, CommandEnum.AUTO_ACTIVATE],
-          },
-        );
+      const configData = await safeInvoke<Record<string, boolean | string>>(
+        CommandEnum.GET_CONFIG_VALUES,
+        {
+          keys: [CommandEnum.VERSIONS_PATH, CommandEnum.DOWNLOAD_PATH, CommandEnum.AUTO_ACTIVATE],
+        },
+      );
 
-        const { versionsPath, downloadPath } = keysToCamel(configData);
+      const { versionsPath, downloadPath, autoActivate } = keysToCamel(configData);
 
-        setDownloadPath(downloadPath as string);
-        setVersionsPath(versionsPath as string);
-        setBasePath(defaultPath);
-      } catch (e) {
-        console.error(e);
-      }
+      form.setFieldsValue({
+        newValues: {
+          download_path: downloadPath,
+          versions_path: versionsPath,
+          auto_activate: autoActivate,
+        },
+      });
     };
+
     void init();
   }, []);
 
-  const handleSave = async () => {
-    // await store.set('base_path', basePath);
-    // await store.save(); // 持久化到硬盘
-    message.success(t('settings.success'));
+  const handleSave = async (values: Record<string, unknown>) => {
+    try {
+      await safeInvoke(CommandEnum.UPDATE_CONFIG, values);
+      message.success(t('settings.success'));
+    } catch (error) {
+      message.error((error as Error).message);
+    }
   };
 
   return (
     <Card title={t('settings.title')}>
-      <Form layout="vertical" onFinish={handleSave}>
-        {basePath && (
-          <Form.Item label={t('settings.base_path')}>
-            <Input
-              value={basePath}
-              onChange={e => setBasePath(e.target.value)}
-              placeholder={t('settings.placeholder', { path: basePath })}
-            />
-          </Form.Item>
-        )}
-        {downloadPath && (
-          <Form.Item label={t('settings.download_path')}>
-            <Input
-              value={downloadPath}
-              onChange={e => setDownloadPath(e.target.value)}
-              placeholder={t('settings.placeholder', { path: downloadPath })}
-            />
-          </Form.Item>
-        )}
-        {versionsPath && (
-          <Form.Item label={t('settings.versions_path')}>
-            <Input
-              value={versionsPath}
-              onChange={e => setVersionsPath(e.target.value)}
-              placeholder={t('settings.placeholder', { path: versionsPath })}
-            />
-          </Form.Item>
-        )}
-        <Button onClick={handleSave}>{t('settings.save')}</Button>
+      <Form form={form} layout="vertical" onFinish={handleSave}>
+        <Form.Item name={['newValues', 'download_path']} label={t('settings.download_path')}>
+          <Input />
+        </Form.Item>
+
+        <Form.Item name={['newValues', 'versions_path']} label={t('settings.versions_path')}>
+          <Input />
+        </Form.Item>
+
+        <Form.Item
+          name={['newValues', 'auto_activate']}
+          label={t('settings.auto_activate')}
+          valuePropName="checked"
+        >
+          <Switch />
+        </Form.Item>
+
+        <Button type="primary" htmlType="submit">
+          {t('settings.save')}
+        </Button>
       </Form>
     </Card>
   );


### PR DESCRIPTION
## 📌 变更类型

- [ ] 🐞 Bug 修复
- [x] ✨ 新功能
- [ ] 💥 破坏性变更 (Breaking Change)
- [ ] ♻️ 重构
- [ ] 🎨 代码风格改进
- [ ] ⚡ 性能优化
- [ ] 🛡️ 安全改进
- [ ] 🧪 测试相关
- [ ] 📚 文档更新
- [ ] 🔧 构建/CI 相关
- [ ] 📦 依赖更新
- [ ] 🔧 其他

---

## 🧾 变更说明
   - 添加统一的 API 响应处理机制，支持错误抛出
   - 重构 Settings 页面，使用 Form 组件简化代码
   - 新增自动激活配置选项
   - 修复 PythonManagePage 搜索功能
   - 更新 ESLint 和 Prettier 配置
   - 补充缺失的国际化翻译
---

## 🔍 相关 Issue

Closes #

---

## 🧪 前端（如涉及改动）
- [x] 本地运行通过
- [x] TypeScript 检查通过
- [x] Lint 通过
- [x] Build 成功

---

## 🦀 Rust / Tauri（如涉及改动）
- [x] cargo check 通过
- [x] cargo fmt 已执行
- [x] cargo clippy 无警告
- [x] Tauri 运行正常

## 📷 截图（如有）

![img_v3_02vi_05290dda-82b0-4b85-a166-791e04f855bg](https://github.com/user-attachments/assets/cc343143-b905-435c-a299-977d7c3bd283)


---

## ⚠️ 注意事项

是否有破坏性更改？
- [ ] 是
- [x] 否