### PR TITLE
feat(version-manager): add install status filter to version table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ target
 package-lock.json
 pnpm-lock.yaml
 .qoder
+.iflow

--- a/src/core/constants/enum.ts
+++ b/src/core/constants/enum.ts
@@ -22,6 +22,13 @@ export enum InstallStatusEnum {
   UNINSTALLED = 'uninstall',
 }
 
+// 0是全部 1已安装 2未安装
+export enum InstallStatusFilterEnum {
+  ALL = 0,
+  INSTALLED = 1,
+  UNINSTALLED = 2,
+}
+
 export enum LanguageEnum {
   PYTHON = 'python',
   GO = 'go',

--- a/src/core/types/common.ts
+++ b/src/core/types/common.ts
@@ -1,13 +1,21 @@
 import { InvokeArgs } from '@tauri-apps/api/core';
 
+import { InstallStatusFilterEnum } from '@/core/constants/enum';
+
 export interface ISearchPayload {
   language: string;
   page: number;
   pageSize: number;
   keyWord: string;
+  installStatus?: number; // 0: all, 1: installed, 2: uninstalled
 }
 
 export type SearchPayload = ISearchPayload & InvokeArgs;
+
+export interface SearchFormValues {
+  keyword?: string;
+  installStatus?: InstallStatusFilterEnum;
+}
 
 export interface VersionItem {
   version: string;

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -40,7 +40,13 @@
   },
   "search": {
     "placeholder": "Input search version",
-    "button": "Search"
+    "button": "Search",
+    "keyword": "Version",
+    "install_status": "Install Status",
+    "install_status_all": "All",
+    "install_status_installed": "Installed",
+    "install_status_uninstalled": "Not Installed",
+    "reset": "Reset"
   },
   "settings": {
     "title": "Global Path Settings",

--- a/src/features/i18n/locales/zh.json
+++ b/src/features/i18n/locales/zh.json
@@ -40,7 +40,13 @@
   },
   "search": {
     "placeholder": "输入目标版本号",
-    "button": "搜索"
+    "button": "搜索",
+    "keyword": "版本号",
+    "install_status": "安装状态",
+    "install_status_all": "全部",
+    "install_status_installed": "已安装",
+    "install_status_uninstalled": "未安装",
+    "reset": "重置"
   },
   "settings": {
     "title": "全局路径设置",

--- a/src/features/version-manager/pages/LanguageManagePage/index.tsx
+++ b/src/features/version-manager/pages/LanguageManagePage/index.tsx
@@ -2,27 +2,40 @@ import { message } from 'antd';
 import { useEffect, useState } from 'react';
 
 import { safeInvoke } from '@/api/tauri';
-import { CommandEnum, InstallStatusEnum, LanguageEnum } from '@/core/constants/enum';
-import { SearchPayload, VersionItem, VersionResult } from '@/core/types/common.ts';
+import {
+  CommandEnum,
+  InstallStatusEnum,
+  InstallStatusFilterEnum,
+  LanguageEnum,
+} from '@/core/constants/enum';
+import type {
+  SearchFormValues,
+  SearchPayload,
+  VersionItem,
+  VersionResult,
+} from '@/core/types/common';
 import { VersionTable } from '@/shared/components/VersionTable';
 
 interface LanguageManagePageProps {
   language: LanguageEnum;
 }
 
+const defaultData: VersionResult = {
+  total: 0,
+  list: [],
+  page: 0,
+  pageSize: 10,
+};
+
 export const LanguageManagePage = ({ language }: LanguageManagePageProps) => {
   const [loading, setLoading] = useState(false);
-  const [data, setData] = useState<VersionResult>({
-    total: 0,
-    list: [],
-    page: 0,
-    pageSize: 10,
-  });
+  const [data, setData] = useState<VersionResult>(defaultData);
   const [searchPayload, setSearchPayload] = useState<SearchPayload>({
     language,
     page: 0,
     pageSize: 10,
     keyWord: '',
+    installStatus: InstallStatusFilterEnum.ALL,
   });
 
   useEffect(() => {
@@ -45,8 +58,24 @@ export const LanguageManagePage = ({ language }: LanguageManagePageProps) => {
     void getList();
   }, [searchPayload]);
 
-  const handleSearch = (keyWord: string) => {
-    setSearchPayload(prevState => ({ ...prevState, keyWord, page: 0 }));
+  const handleSearch = (values: SearchFormValues) => {
+    setData(defaultData);
+    setSearchPayload(prevState => ({
+      ...prevState,
+      keyWord: values.keyword || '',
+      installStatus: values.installStatus,
+      page: 0,
+    }));
+  };
+
+  const handleReset = () => {
+    setSearchPayload({
+      language,
+      page: 0,
+      pageSize: 10,
+      keyWord: '',
+      installStatus: InstallStatusFilterEnum.ALL,
+    });
   };
 
   const handlePageChange = (page: number, pageSize: number) => {
@@ -74,6 +103,7 @@ export const LanguageManagePage = ({ language }: LanguageManagePageProps) => {
       data={data}
       handleVersionAction={handleVersionAction}
       onSearch={handleSearch}
+      onReset={handleReset}
       handlePageChange={handlePageChange}
     />
   );

--- a/src/mock/handlers.ts
+++ b/src/mock/handlers.ts
@@ -7,9 +7,22 @@ import { SearchPayload } from '@/core/types/common';
 export const mockHandlers = {
   [CommandEnum.GET_CONFIG_VALUES]: () => mockConfig,
   [CommandEnum.LIST_VERSIONS]: (args?: SearchPayload) => {
-    if (args?.language === LanguageEnum.NODE) {
-      return mockNodeVersions;
+    const sourceData = args?.language === LanguageEnum.NODE ? mockNodeVersions : mockVersions;
+
+    // 如果有过滤条件，进行过滤 (0: all, 1: installed, 2: uninstalled)
+    if (args?.installStatus && args.installStatus !== 0) {
+      const targetStatus = args.installStatus === 1;
+      const filteredList = sourceData.data.list.filter(item => item.installStatus === targetStatus);
+      return {
+        ...sourceData,
+        data: {
+          ...sourceData.data,
+          list: filteredList,
+          total: filteredList.length,
+        },
+      };
     }
-    return mockVersions;
+
+    return sourceData;
   },
 };

--- a/src/shared/components/VersionTable/components/SearchForm/index.css
+++ b/src/shared/components/VersionTable/components/SearchForm/index.css
@@ -1,0 +1,20 @@
+.search-form {
+  display: flex;
+  /* align-items: center; */
+  justify-content: center;
+  padding: 12px;
+  background-color: white;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.05);
+  border-radius: 12px;
+  margin-bottom: 24px;
+  gap: 16px;
+}
+
+.search-form .ant-form-item {
+  margin-bottom: 0;
+}
+
+.search-form .search-form-button-group {
+  display: flex;
+  gap: 8px;
+}

--- a/src/shared/components/VersionTable/components/SearchForm/index.tsx
+++ b/src/shared/components/VersionTable/components/SearchForm/index.tsx
@@ -1,0 +1,60 @@
+import { Button, Form, Input, Select } from 'antd';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { InstallStatusFilterEnum } from '@/core/constants/enum';
+import type { SearchFormValues } from '@/core/types/common';
+
+import './index.css';
+
+interface SearchFormProps {
+  onSearch: (values: SearchFormValues) => void;
+  onReset?: () => void;
+  initialValues?: SearchFormValues;
+  loading?: boolean;
+}
+
+export const SearchForm: React.FC<SearchFormProps> = ({
+  onSearch,
+  onReset,
+  initialValues,
+  loading,
+}) => {
+  const [form] = Form.useForm();
+  const { t } = useTranslation();
+
+  const handleSearch = () => {
+    const values = form.getFieldsValue();
+    onSearch(values);
+  };
+
+  const handleReset = () => {
+    form.resetFields();
+    onReset?.();
+  };
+
+  const installStatusOptions = [
+    { value: InstallStatusFilterEnum.ALL, label: t('search.install_status_all') },
+    { value: InstallStatusFilterEnum.INSTALLED, label: t('search.install_status_installed') },
+    { value: InstallStatusFilterEnum.UNINSTALLED, label: t('search.install_status_uninstalled') },
+  ];
+
+  return (
+    <Form form={form} className="search-form" initialValues={initialValues} layout="inline">
+      <Form.Item name="keyword" label={t('search.keyword')}>
+        <Input placeholder={t('search.placeholder')} />
+      </Form.Item>
+      <Form.Item name="installStatus" label={t('search.install_status')}>
+        <Select options={installStatusOptions} style={{ width: 120 }} />
+      </Form.Item>
+      <Form.Item>
+        <div className="search-form-button-group">
+          <Button onClick={handleReset}>{t('search.reset')}</Button>
+          <Button type="primary" onClick={handleSearch} loading={loading}>
+            {t('search.button')}
+          </Button>
+        </div>
+      </Form.Item>
+    </Form>
+  );
+};

--- a/src/shared/components/VersionTable/index.tsx
+++ b/src/shared/components/VersionTable/index.tsx
@@ -1,17 +1,19 @@
 import type { TableProps } from 'antd';
-import { Table, Input, Button } from 'antd';
+import { Button, Table } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { CommandEnum, InstallStatusEnum } from '@/core/constants/enum';
-import { VersionItem, VersionResult } from '@/core/types/common';
+import { SearchForm } from './components/SearchForm';
 
 import './index.css';
+import { CommandEnum, InstallStatusEnum, InstallStatusFilterEnum } from '@/core/constants/enum';
+import type { SearchFormValues, VersionItem, VersionResult } from '@/core/types/common';
 
 interface VersionTableProps {
   data: VersionResult;
   loading?: boolean;
-  onSearch?: (value: string) => void;
+  onSearch?: (values: SearchFormValues) => void;
+  onReset?: () => void;
   handlePageChange: (page: number, pageSize: number) => void;
   handleVersionAction?: (
     command: CommandEnum | InstallStatusEnum,
@@ -23,6 +25,7 @@ export const VersionTable: React.FC<VersionTableProps> = ({
   data,
   loading,
   onSearch,
+  onReset,
   handleVersionAction,
   handlePageChange,
 }) => {
@@ -80,15 +83,14 @@ export const VersionTable: React.FC<VersionTableProps> = ({
   return (
     <>
       <div style={{ marginBottom: 12, marginTop: 12, textAlign: 'center' }}>
-        <Input.Search
-          placeholder={t('search.placeholder')}
-          enterButton={t('search.button')}
-          onSearch={onSearch}
-          style={{
-            marginBottom: 12,
-            width: '100%',
-            maxWidth: 400,
+        <SearchForm
+          onSearch={onSearch || (() => {})}
+          onReset={onReset}
+          initialValues={{
+            keyword: '',
+            installStatus: InstallStatusFilterEnum.ALL,
           }}
+          loading={loading}
         />
       </div>
 


### PR DESCRIPTION
## 📌 变更类型

- [ ] 🐞 Bug 修复
- [x] ✨ 新功能
- [ ] 💥 破坏性变更 (Breaking Change)
- [ ] ♻️ 重构
- [ ] 🎨 代码风格改进
- [ ] ⚡ 性能优化
- [ ] 🛡️ 安全改进
- [ ] 🧪 测试相关
- [ ] 📚 文档更新
- [ ] 🔧 构建/CI 相关
- [ ] 📦 依赖更新
- [ ] 🔧 其他

---

## 🧾 变更说明

请简要说明本次 PR 做了什么。

  - 新增 InstallStatusFilterEnum 枚举（0:全部, 1:已安装, 2:未安装）
  - 重构 SearchForm 组件，支持版本号和安装状态组合搜索
  - 更新 VersionTable 和 LanguageManagePage 组件
  - 添加中英文国际化支持
  - 更新 Mock 数据处理逻辑

---

## 🔍 相关 Issue

Closes #

---

## 🧪 前端（如涉及改动）
- [x] 本地运行通过
- [x] TypeScript 检查通过
- [x] Lint 通过
- [x] Build 成功

---

## 🦀 Rust / Tauri（如涉及改动）
- [ ] cargo check 通过
- [ ] cargo fmt 已执行
- [ ] cargo clippy 无警告
- [ ] Tauri 运行正常

## 📷 截图（如有）

<img width="2188" height="1372" alt="image" src="https://github.com/user-attachments/assets/f366d572-9f33-4b65-b6b7-9950467d13bd" />

---

## ⚠️ 注意事项

是否有破坏性更改？
- [ ] 是
- [x] 否